### PR TITLE
bugfix remove synchronized for Helper's methods

### DIFF
--- a/JavaConcurrencyPatternInAction/src/io/github/viscent/mtpattern/ch4/gs/example/NestedMonitorLockoutExample.java
+++ b/JavaConcurrencyPatternInAction/src/io/github/viscent/mtpattern/ch4/gs/example/NestedMonitorLockoutExample.java
@@ -68,7 +68,7 @@ public class NestedMonitorLockoutExample {
 
 		private final Blocker blocker = new ConditionVarBlocker();
 
-		public synchronized String xGuarededMethod(final String message) {
+		public String xGuarededMethod(final String message) {
 			GuardedAction<String> ga = new GuardedAction<String>(stateBeOK) {
 
 				@Override
@@ -86,7 +86,7 @@ public class NestedMonitorLockoutExample {
 			return result;
 		}
 
-		public synchronized void xStateChanged() {
+		public void xStateChanged() {
 			try {
 				blocker.signalAfter(new Callable<Boolean>() {
 


### PR DESCRIPTION
the origin impl use synchronized for those xGuarededMethod,xStateChanged methods,cannot run as respect cause those two methods always need to run in parallel 